### PR TITLE
Update project.yml

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -4,8 +4,8 @@ settings:
     pdf_enabled: true
   prod:
     pdf_enabled: true
+    harmony_enabled: true
   search: ontap
-  harmony_enabled: true
 homepage:
   tiles:
     - title: Get started


### PR DESCRIPTION
@akseldavis @ntap-bmegan @dmajones 

The `harmony_enabled` variable must be enabled in the correct environment, not globally.


This configuration generates that Harmony is enabled both in the internal repositories and in production.
```yaml
settings:
  name: System Manager Classic
  internal:
    pdf_enabled: true
  prod:
    pdf_enabled: true
  search: ontap
  harmony_enabled: true
```


I have moved the `harmony_enabled` variable so that it is only enabled in production.

```yaml
settings:
  name: System Manager Classic
  internal:
    pdf_enabled: true
  prod:
    pdf_enabled: true
    harmony_enabled: true
  search: ontap
```
